### PR TITLE
Add Hadoop Weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,13 @@ every Sunday in the form of the DevOps newsletter.
 * [Android Authority Dev Weekly](http://devweekly.androidauthority.com/). Android Authority Dev Weekly is a weekly curated publication full of interesting, relevant links for Android developers.
 * [Android Weekly](http://androidweekly.net/) Free newsletter that helps you to stay cutting-edge with your Android Development.
 
+## Big Data
+* [Big Data Weekly](http://www.bigdataweekly.com/). Big Data technology news and links delivered to your inbox, weekly.
+* [Data Science Weekly Newsletter](http://www.datascienceweekly.org/). A free weekly newsletter featuring curated news, articles and jobs related to Data Science.
+* [Hadoop Weekly](http://www.hadoopweekly.com/). Summary of the week's top news in the Apache Hadoop™ ecosystem.
+
 ## Etc.
 * A free weekly newsletter featuring the best and hand curated links related to domains, development, monetization, how to guides, tips and tricks, resources, events and more. [This Week in Domains](http://www.thisweekindomains.com/)
-* [Data Science Weekly Newsletter](http://www.datascienceweekly.org/). A free weekly newsletter featuring curated news, articles and jobs related to Data Science.
 * Inspiration in your inbox by [TED](https://www.ted.com/newsletter).
 * Projects We Love archive by [KickStarter](https://www.kickstarter.com/newsletters/weekly).
 * [Bitcoin Weekly](http://bitcoinweekly.com/). A weekly round-up of Bitcoin and cryptocurrency news and articles.
@@ -157,7 +161,6 @@ every Sunday in the form of the DevOps newsletter.
 * [Founder Weekly](http://www.founderweekly.com/). A free weekly newsletter for entrepreneurs featuring best curated content, must read articles, how to guides, tips and tricks, resources, events and more.
 * [Reddit's Official Newsletter](https://www.reddit.com/newsletter). Best of reddit's content curated, packaged, and delivered to your inbox once a week.
 * [WebRTC Weekly](https://webrtcweekly.com/). A weekly & brief newsletter with all the latest news and activities on WebRTC.
-* [Big Data Weekly](http://www.bigdataweekly.com/). Big Data technology news and links delivered to your inbox, weekly.
 
 
 # License


### PR DESCRIPTION
Adding http://www.hadoopweekly.com - a summary of the week's top news in the Apache Hadoop™ ecosystem. It's aimed at developers or those trying to keep on top of the latest Hadoop developments.

Extracting Big Data to the top-level category