### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md
+  - awesome_bot README.md -w reactnative.cc,designernews,reddit

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Thanks to all [contributors](https://github.com/vredniy/awesome-newsletters/grap
 
 
 ## Frontend
-* [SitePoint](http://www.sitepoint.com/newsletter/). [Archive](http://www.sitepoint.com/newsletter-archive/).
+* [SitePoint](https://www.sitepoint.com/newsletter/). [Archive](https://www.sitepoint.com/newsletter-archive/).
 * [Front-end Front](http://frontendfront.us9.list-manage.com/subscribe?u=b033c4814d034fca4f850fe82&id=ceaf5763d0). [Frontendfront](https://frontendfront.com/)
 * [Front End Newsletter](http://frontendnewsletter.com/). The free, weekly newsletter of the best Front End related news, articles, projects, and more. JavaScript, React, Angular, Ember, Polymer, Meteor, RxJS, Elm, and more. [Archive](http://frontendnewsletter.com/issues).
 * [Dev Tips](https://umaar.com/dev-tips/). A developer tip, in the form of a gif, in your inbox each week.
@@ -36,7 +36,7 @@ Thanks to all [contributors](https://github.com/vredniy/awesome-newsletters/grap
 
 #### React
 * [ReactJS Newsletter](http://reactjsnewsletter.com/). The free, weekly newsletter of the best React.js news and articles.
-* [React Native Newsletter](http://brentvatne.ca/react-native-newsletter/). Free occasional summary of React Native news, articles, issues & pull requests, libraries and apps.
+* [React Native Newsletter](http://reactnative.cc/). Free occasional summary of React Native news, articles, issues & pull requests, libraries and apps.
 * [Fullstack React](http://newsletter.fullstackreact.com/). Newsletter about the React ecosystem with an emphasis on useful libraries, tutorials and code. [Archive](http://newsletter.fullstackreact.com/issues).
 * [React Digest](https://www.getrevue.co/profile/the-react-digest). A hand-picked weekly selection of the best React JS resources.
 
@@ -190,7 +190,7 @@ every Sunday in the form of the DevOps newsletter.
 
 ## Technology in General
 * [Barista.io](http://www.barista.io/). Stay on top of today's most popular Tech news with a daily e-mail of crowd-curated articles from across the Web.
-* [Four Short Links](http://radar.oreilly.com/four-short-links). 4 short links about (mostly research oriented) technology every weekday.
+* [Four Short Links](https://www.oreilly.com/feed/four-short-links). 4 short links about (mostly research oriented) technology every weekday.
 * [The Morning Paper](https://blog.acolyer.org/). An interesting/influential/important paper from the world of CS every weekday morning, as selected by Adrian Colyer.
 
 ## Etc.


### PR DESCRIPTION
Updated some links (redirects) and ci to fix the build

Created with https://github.com/dkhamsing/frankenstein

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://www.sitepoint.com/newsletter-archive/ | https://www.sitepoint.com/newsletter-archive/ 
http://www.sitepoint.com/newsletter/ | https://www.sitepoint.com/newsletter/ 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://brentvatne.ca/react-native-newsletter/ | http://reactnative.cc/ 
http://radar.oreilly.com/four-short-links | https://www.oreilly.com/feed/four-short-links 
