### PR TITLE
Add Better Dev Link News Letter

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ every Sunday in the form of the DevOps newsletter.
 * [My Morning Routine](https://mymorningroutine.com/). My Morning Routine is an independent online magazine that brings you a brand new, inspiring morning routine every Wednesday.
 * [wpMail.me](http://wpmail.me/). A free WordPress Newsletter, once a week, with a round-up of WordPress news and articles. [Archive](http://wpmail.me/newsletters/).
 * [Handwritten newsletter](http://www.thnkclrly.com/newsletter/). The Think Clearly newsletter gives you little reflection exercises to help you in your daily life. It is created with love and admiration. [Archive](http://www.thnkclrly.com/category/thinking-clearly/).
+* [Better Dev Link](https://betterdev.link). A weekly newsletter, collects links that aim to improve programming knowledge general. The purpose is not include the links that reader can search instantly from google such as how to do x, y, z but more about problem solving in programming.
 
 
 ## Etc.


### PR DESCRIPTION
This is a weekly newsletter, collects links that aim to improve programming knowledge general. 

The purpose is not include the links that reader can search instantly from google such as how to do x, y, z but more about problem solving in programming.

Example: The news letter will not have link such as "how to build a JSON API with Elixir", "How to use Flexbox" but will more about "improving performance with Elixir", "Common pitfall when using x" etc.

Thanks.