### PR TITLE
Remove laravel-weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Thanks to all [contributors](https://github.com/vredniy/awesome-newsletters/grap
 
 ### PHP
 * [PHP Weekly](http://www.phpweekly.com/). A free once-a-week newsletter, featuring some great articles, news and blog posts.
-* [Laravel Weekly Newsletter](http://laravelweekly.com/). Laravel PHP framework.
 * [Laravel News](https://laravel-news.com/). Every week lots of tips, tutorials, and packages are released for Laravel.
 * [Awesome PHP Newsletter](https://php.libhunt.com/newsletter). A curated list of awesome PHP libraries and resources.
 * [murze.be newsletter](https://murze.be/newsletter/). A bi weekly newsletter on modern PHP and Laravel.


### PR DESCRIPTION
Laravel weekly newsletter is on hold.

Check here -
https://github.com/laravelio/laravel-weekly

The last issue was published in year 2014.