### PR TITLE
Add Friday Front-end newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Thanks to all [contributors](https://github.com/vredniy/awesome-newsletters/grap
 * [Front-end Front](http://frontendfront.us9.list-manage.com/subscribe?u=b033c4814d034fca4f850fe82&id=ceaf5763d0). [Frontendfront](https://frontendfront.com/)
 * [Front End Newsletter](http://frontendnewsletter.com/). The free, weekly newsletter of the best Front End related news, articles, projects, and more. JavaScript, React, Angular, Ember, Polymer, Meteor, RxJS, Elm, and more. [Archive](http://frontendnewsletter.com/issues).
 * [Dev Tips](https://umaar.com/dev-tips/). A developer tip, in the form of a gif, in your inbox each week.
+* [Friday Front-end](https://zendev.com/friday-frontend.html). 15 great Front-end articles, tutorials, and announcements every Friday. Sections for CSS/SCSS, JavaScript, and other awesome stuff. [Archive](https://zendev.com/category/friday-frontend.html)
 
 ### General Web Development
 * [Weekend Reading](http://tinyletter.com/assaf). A weekly email about Web development, design and the startup life.


### PR DESCRIPTION
Adds the ZenDev Friday Front-end newsletter to the Frontend section. Full disclosure: I publish this newsletter, so you may want to independently validate the quality; I include an archives link to take a look.