### PR TITLE
Add Adapt or Die to AI / ML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,6 +429,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Air Around AI](https://airaroundai.substack.com/). Air Around AI is a weekly newsletter of the top news, best tutorials, product launches and super tips on AI.
 - [The Batch](https://www.deeplearning.ai/the-batch/). The weekly DeepLearning.AI newsletter that highlights the most practical research papers, industry shaping applications and high impact business news.
 - [Augmented Coding Weekly](https://augmentedcoding.dev/). A weekly newsletter that takes a hype-free look at the latest news about AI-augmented software development and vibe coding, with a focus on how it is changing the software industry
+- [Adapt or Die](https://adaptordie.io). Independent analysis of AI's impact on commerce — covering agentic commerce, AI infrastructure spending, and digital transformation with long-form, zero-hype takes.
 
 ## Blockchain / Cryptocurrencies
 


### PR DESCRIPTION
## Newsletter Details

- **Name**: [Adapt or Die](https://adaptordie.io)
- **Category**: Artificial Intelligence / Machine Learning
- **Focus**: AI's impact on commerce and business transformation

## Description

Adapt or Die provides independent, long-form analysis covering:

- Agentic commerce — AI agents reshaping buying and selling
- AI infrastructure spending — the $650B+ capex cycle and its implications  
- Digital transformation — practical business impacts of AI adoption
- Future of work — how AI changes operations, roles, and strategy

The newsletter takes a zero-hype, evidence-based approach with contrarian analysis rather than trend-chasing. UK perspective on global AI developments.

## Why it fits the AI/ML section

Unlike most AI newsletters that cover general tech news, Adapt or Die specifically analyses how AI and ML models are transforming commerce — one of the largest application domains for AI. It complements the existing entries which focus on research, tools, and general AI news.

## Checklist

- [x] Newsletter is free to subscribe
- [x] Regular publication schedule  
- [x] Added in appropriate section (AI/ML)
- [x] Description follows existing format