### PR TITLE
Add JVM Weekly to Java section

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Awesome Java Newsletter](https://java.libhunt.com/newsletter). A curated list of awesome Java frameworks, libraries and software.
 - [Baeldung Weekly Review](https://www.baeldung.com/java-web-weekly). Keep up-to-date with the main developments in the Java world through this weekly guide.
 - [Java Newsletter Insights](https://curatedjava.com/java-weekly-newsletter/). A Java newsletter contemplating Java content curated from dozens of sources.
+- [JVM Weekly](https://www.jvm-weekly.com/). A weekly newsletter by Artur Skowronski covering the JVM ecosystem, including Java, Kotlin, Scala, GraalVM, Quarkus and related technologies.
 
 ### Kotlin
 


### PR DESCRIPTION
## Summary

- Add [JVM Weekly](https://www.jvm-weekly.com/) to the Java section.
- JVM Weekly is a weekly newsletter by Artur Skowronski covering the JVM ecosystem, including Java, Kotlin, Scala, GraalVM, Quarkus and related technologies.
- Placed at the bottom of the Java category per the contributing guidelines.

## Checklist

- [x] Searched for duplicates before submitting
- [x] Used the correct format: `[Package](link). Description.`
- [x] Added to the bottom of the relevant category
- [x] Description starts with a capital and ends with a full stop
- [x] Spelling and grammar checked