### PR TITLE
Add MAX Newsletter to Artificial Intelligence section

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 
 ## Artificial Intelligence / Machine Learning / Big Data
 
+- [MAX Newsletter](https://web-delta-ten-70.vercel.app). Weekly AI-curated digest for B2B founders — the latest AI tools, research and business insights, curated by AI and delivered in a 5-minute weekly read.
 - [Data Elixir](https://dataelixir.com/). A weekly newsletter of the best data science news and resources from around the web. [Archive](https://dataelixir.com/newsletters/).
 - [Artificial Intelligence Weekly](http://aiweekly.co/). A weekly collection of the best news and resources on Artificial Intelligence amd Machine Learning.
 - [Machine Learnings](http://subscribe.machinelearnings.co/). A weekly roundup of ML & AI news.


### PR DESCRIPTION
## What's this?

Adds [MAX Newsletter](https://web-delta-ten-70.vercel.app) to the **Artificial Intelligence / Machine Learning / Big Data** section.

## About MAX Newsletter

- **Name**: MAX Newsletter
- **URL**: https://web-delta-ten-70.vercel.app
- **Tagline**: Weekly AI-curated digest for B2B founders
- **Description**: The latest AI tools, research and business insights — curated by AI and delivered in a 5-minute weekly read
- **Frequency**: Weekly
- **Free**: Yes
- **Category**: AI / Business / B2B

MAX is an automated newsletter powered by Claude AI that curates and scores articles from leading AI/tech sources, assembling a weekly digest tailored for B2B founders and professionals who need to stay current on AI trends.