### PR TITLE
Add 8bitconcepts Research to AI / ML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [The Batch](https://www.deeplearning.ai/the-batch/). The weekly DeepLearning.AI newsletter that highlights the most practical research papers, industry shaping applications and high impact business news.
 - [Augmented Coding Weekly](https://augmentedcoding.dev/). A weekly newsletter that takes a hype-free look at the latest news about AI-augmented software development and vibe coding, with a focus on how it is changing the software industry
 - [Adapt or Die](https://adaptordie.io). Independent analysis of AI's impact on commerce — covering agentic commerce, AI infrastructure spending, and digital transformation with long-form, zero-hype takes.
+- [8bitconcepts Research](https://8bitconcepts.com/). Original research on AI governance, agent accountability, and enterprise adoption. Data-backed analysis covering the agentic accountability gap, hallucination budgets, and deployment patterns.
 
 ## Blockchain / Cryptocurrencies
 


### PR DESCRIPTION
Adds [8bitconcepts Research](https://8bitconcepts.com) to the Artificial Intelligence / Machine Learning / Big Data section.

8bitconcepts publishes original research on AI governance, agent accountability, and enterprise adoption. 11 papers published to date covering topics like the agentic accountability gap, hallucination budgets, and deployment failure patterns. Available via web and RSS feed.