### PR TITLE
Add AI Dev Jobs Weekly to AI / ML section

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [The Batch](https://www.deeplearning.ai/the-batch/). The weekly DeepLearning.AI newsletter that highlights the most practical research papers, industry shaping applications and high impact business news.
 - [Augmented Coding Weekly](https://augmentedcoding.dev/). A weekly newsletter that takes a hype-free look at the latest news about AI-augmented software development and vibe coding, with a focus on how it is changing the software industry
 - [Adapt or Die](https://adaptordie.io). Independent analysis of AI's impact on commerce — covering agentic commerce, AI infrastructure spending, and digital transformation with long-form, zero-hype takes.
+- [AI Dev Jobs Weekly](https://aidevboard.com). A weekly digest of the latest AI and machine learning developer jobs from 280+ companies including Anthropic, OpenAI, and DeepMind.
 
 ## Blockchain / Cryptocurrencies
 


### PR DESCRIPTION
Adds [AI Dev Jobs Weekly](https://aidevboard.com) to the Artificial Intelligence / Machine Learning / Big Data section.

**AI Dev Jobs Weekly** is a free weekly newsletter delivering the latest AI and machine learning developer jobs from 280+ companies including Anthropic, OpenAI, DeepMind, and more. Subscribe via the homepage at https://aidevboard.com.

- Entry added to the bottom of the relevant category per contribution guidelines
- Format matches existing entries: `[Name](link). Description.`