### PR TITLE
Add Creative AI News to AI/ML/Big Data section

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Augmented Coding Weekly](https://augmentedcoding.dev/). A weekly newsletter that takes a hype-free look at the latest news about AI-augmented software development and vibe coding, with a focus on how it is changing the software industry
 - [Adapt or Die](https://adaptordie.io). Independent analysis of AI's impact on commerce — covering agentic commerce, AI infrastructure spending, and digital transformation with long-form, zero-hype takes.
 - [AI Dev Jobs Weekly](https://aidevboard.com). A weekly digest of the latest AI and machine learning developer jobs from 280+ companies including Anthropic, OpenAI, and DeepMind.
+- [Creative AI News](https://www.creativeainews.com). Weekly AI tools and workflows for every working creator: image, video, audio, 3D, and code.
 
 ## Blockchain / Cryptocurrencies
 


### PR DESCRIPTION
Adding [Creative AI News](https://www.creativeainews.com), a weekly newsletter covering AI tools and workflows for working creators across image, video, audio, 3D, and code.

Quick context:
- 411 published articles, weekly cadence
- Pillar guides covering AI Video, AI Image, ComfyUI, AI Coding, AI Music, and Open-Source AI
- Editorial focus on what ships for creators, not benchmark sheets

Added one entry to the Artificial Intelligence / Machine Learning / Big Data section, matching the existing format.