### PR TITLE
Add AI Week Radar under AI section

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Augmented Coding Weekly](https://augmentedcoding.dev/). A weekly newsletter that takes a hype-free look at the latest news about AI-augmented software development and vibe coding, with a focus on how it is changing the software industry
 - [Adapt or Die](https://adaptordie.io). Independent analysis of AI's impact on commerce — covering agentic commerce, AI infrastructure spending, and digital transformation with long-form, zero-hype takes.
 - [AI Dev Jobs Weekly](https://aidevboard.com). A weekly digest of the latest AI and machine learning developer jobs from 280+ companies including Anthropic, OpenAI, and DeepMind.
+- [AI Week Radar](https://aiweekradar.com/) - 8 curated AI stories every Friday for engineers and founders. Free, no tracking, EN + PL.
 
 ## Blockchain / Cryptocurrencies
 


### PR DESCRIPTION
AI Week Radar is a curated weekly newsletter for developers and decision-makers working with AI. ~8 stories every Friday, each with a short editor's note. Polish edition available.

Follows repo conventions:
- Free + permanent archive at https://aiweekradar.com/archive
- 1-click unsubscribe, no tracking
- Polish localization at /pl/