### PR TITLE
Add DevAI Semanal — weekly AI dev tools newsletter in Spanish

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Augmented Coding Weekly](https://augmentedcoding.dev/). A weekly newsletter that takes a hype-free look at the latest news about AI-augmented software development and vibe coding, with a focus on how it is changing the software industry
 - [Adapt or Die](https://adaptordie.io). Independent analysis of AI's impact on commerce — covering agentic commerce, AI infrastructure spending, and digital transformation with long-form, zero-hype takes.
 - [AI Dev Jobs Weekly](https://aidevboard.com). A weekly digest of the latest AI and machine learning developer jobs from 280+ companies including Anthropic, OpenAI, and DeepMind.
+- [DevAI Semanal](https://devaisemanal.com). A weekly Spanish-language newsletter covering AI developer tools — Claude Code, Cursor, Copilot, MCP servers — curated and written by an automated pipeline using Claude API. [Archive](https://devaisemanal.com).
 
 ## Blockchain / Cryptocurrencies
 


### PR DESCRIPTION
## What is DevAI Semanal?

[DevAI Semanal](https://devaisemanal.com) is a weekly newsletter about AI developer tools (Claude Code, Cursor, Copilot, MCP servers, etc.) written in Spanish.

It's fully automated: a pipeline built with Claude API and GitHub Actions collects news from RSS, Hacker News, Reddit and GitHub Trending, curates the top 5-7 items, rewrites them in Spanish with practical context, and publishes every Tuesday.

- **Website**: https://devaisemanal.com
- **Frequency**: Weekly (Tuesdays)
- **Language**: Spanish
- **Open source pipeline**: https://github.com/Khavel/devai-newsletter
- **Archive**: https://devaisemanal.com

Added to the **Artificial Intelligence / Machine Learning / Big Data** section.