### PR TITLE
Add DiamantAI to AI/ML/Big Data newsletters

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Augmented Coding Weekly](https://augmentedcoding.dev/). A weekly newsletter that takes a hype-free look at the latest news about AI-augmented software development and vibe coding, with a focus on how it is changing the software industry
 - [Adapt or Die](https://adaptordie.io). Independent analysis of AI's impact on commerce — covering agentic commerce, AI infrastructure spending, and digital transformation with long-form, zero-hype takes.
 - [AI Dev Jobs Weekly](https://aidevboard.com). A weekly digest of the latest AI and machine learning developer jobs from 280+ companies including Anthropic, OpenAI, and DeepMind.
+- [DiamantAI](https://diamantai.substack.com). Practical AI engineering and generative AI explained simply, covering RAG, agents, and LLM application patterns for builders.
 
 ## Blockchain / Cryptocurrencies
 


### PR DESCRIPTION
Adding DiamantAI to the Artificial Intelligence / Machine Learning / Big Data section.

[DiamantAI](https://diamantai.substack.com) is a newsletter on practical AI engineering and generative AI (RAG, agents, LLM application patterns) for builders. Sits alongside The Batch, Import AI, and Data Elixir already listed here.

Disclosure: this is my newsletter. Followed the one-newsletter-per-PR and section format from CONTRIBUTING.