### PR TITLE
Update AI Weekly (aiweekly.co) entry: independent, 3x/week, since 2015

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 ## Artificial Intelligence / Machine Learning / Big Data
 
 - [Data Elixir](https://dataelixir.com/). A weekly newsletter of the best data science news and resources from around the web. [Archive](https://dataelixir.com/newsletters/).
-- [Artificial Intelligence Weekly](http://aiweekly.co/). A weekly collection of the best news and resources on Artificial Intelligence amd Machine Learning.
+- [AI Weekly](https://aiweekly.co/). The longest-running independent AI news newsletter, curated since 2015 — the few stories that actually matter, 3x/week, for 44,000+ professionals.
 - [Machine Learnings](http://subscribe.machinelearnings.co/). A weekly roundup of ML & AI news.
 - [Inside AI](https://inside.com/ai). Weekly newsletter bringing you the latest in Artificial Intelligence, Robotics, and Neurotechnology.
 - [Import AI](https://twitter.us13.list-manage.com/subscribe?u=67bd06787e84d73db24fb0aa5&id=6c9d98ff2c). The latest breakthroughs, applications and foul-ups in artificial intelligence. [Archive](https://us13.campaign-archive.com/home/?u=67bd06787e84d73db24fb0aa5&id=6c9d98ff2c)


### PR DESCRIPTION
Refreshes the existing aiweekly.co listing, whose description and http:// link are out of date. The site is now an independent, solo-curated AI news briefing published 3x/week to 44,000+ professionals (running since 2015), not a weekly link roundup. Updates the name to its current "AI Weekly" branding, switches the URL to https, and rewrites the one-line description to match — keeping the list's standard one-sentence format.