### PR TITLE
Add StackTrace Weekly (Programming > General)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Grok](https://grok.computer). Free daily summary of the internet for software engineers. [Archive](https://grok.computer/newsletter)
 - [Tech Talks Weekly](https://techtalksweekly.substack.com/). A free weekly newsletter that brings all the recently uploaded tech talks across [+100 engineering conferences](https://techtalksweekly.substack.com/p/tech-conferences) like Devoxx, NDC, GOTO, StrangeLoop, ... right into your inbox. [Archive](https://techtalksweekly.substack.com/archive).
 - [CodeDegen Daily](https://codedegen.substack.com/) A daily, mostly free, No BS newsletter for programming information in general you'r just one click away.
-- 
+- [StackTrace Weekly](https://stacktrace-web.vercel.app). Changelog triage for 30 dev tools: every change severity-classified (critical/notable/FYI) against a public rubric, every Monday.
 
 ### ObjectiveC
 


### PR DESCRIPTION
Adds [StackTrace Weekly](https://stacktrace-web.vercel.app): a free weekly email that reads the changelogs of 30 developer tools (Stripe, Next.js, Supabase, the AI SDKs, ...) and classifies every change by severity (CRITICAL/NOTABLE/FYI) against a [public rubric](https://stacktrace-web.vercel.app/rubric.html). Every severity claim is backed by a verbatim quote from the release notes. Follows the existing entry format.