### PR TITLE
Add RoundSignal to Business/Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Unvalidated Ideas](https://unvalidatedideas.com). Fresh startup and SaaS ideas that you can take out and market validate every week.
 - [Generated.Company](https://generated.company). Unleash Your Entrepreneurial Potential with AI-Powered Company Ideas. 10 Company ideas every single week.
 - [Indie Hackers Newsletter](https://www.indiehackers.com/newsletter). The best news for founders, not consumers.
+- [RoundSignal](https://getroundsignal.com/). A weekly newsletter listing freshly-funded startups scored for sales-fit, for people who sell services to newly-funded companies.
 
 ## Awesome news
 


### PR DESCRIPTION
Adds [RoundSignal](https://getroundsignal.com/) to the Business/Finance section.

**Link:** https://getroundsignal.com/
**Why it fits:** a weekly curated newsletter for the startup/business world — a natural neighbour to Wellfound Weekly, Startup Curated and Indie Hackers already in this section. Each issue lists freshly-funded startups scored for sales-fit, for people who sell services to newly-funded companies.

Guidelines followed: single suggestion, format `[Package](link). Description.`, added to the bottom of the relevant category, capitalised description ending with a period.