### PR TITLE
Add AI Morsels to Artificial Intelligence / Machine Learning / Big Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Augmented Coding Weekly](https://augmentedcoding.dev/). A weekly newsletter that takes a hype-free look at the latest news about AI-augmented software development and vibe coding, with a focus on how it is changing the software industry
 - [Adapt or Die](https://adaptordie.io). Independent analysis of AI's impact on commerce — covering agentic commerce, AI infrastructure spending, and digital transformation with long-form, zero-hype takes.
 - [AI Dev Jobs Weekly](https://aidevboard.com). A weekly digest of the latest AI and machine learning developer jobs from 280+ companies including Anthropic, OpenAI, and DeepMind.
+- [AI Morsels](https://aimorsels.com/). The AI tools worth your time, every Thursday: a star pick plus three more tools, three reads, and the week’s big-lab releases, each with a one-line verdict.
 
 ## Blockchain / Cryptocurrencies
 


### PR DESCRIPTION
Adds [AI Morsels](https://aimorsels.com/) — a free weekly AI-tools newsletter, sent every Thursday.

Why it should be included: it fits the AI/ML section's newsletter focus — each issue curates a star tool plus three more worth trying, three reads, and the week's big-lab releases, each with a one-line verdict from a software engineer who installs the tools before recommending them. Full public archive at https://aimorsels.com/archive and full-content RSS at https://aimorsels.com/rss.xml, no paywall.

Follows the contribution guidelines: single suggestion, repo line format, added to the bottom of the category.