### PR TITLE
Add TrendPulse to Technology in General

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [mainbranch](https://mainbranch.beehiiv.com/). A short, no-hype newsletter on software engineering fundamentals, practical features for better code, and platform updates that help ship faster.
 - [Take It From The Top](https://takeitfromthe.top/). Daily rundown of AI and tech. Filters out the fluff, keeps the good parts. Covers launches, dev tools, and engineering reads so you're always in the loop. [Archive](https://takeitfromthe.top/).
 - [Tech Byte Daily](https://tech-byte.dev) Free, No-fluff daily tech newsletter for senior software engineers
+- [TrendPulse](https://usagineko7865-debug.github.io/trendpulse/). A daily, fully autonomous digest of trending tech and business videos worldwide, written in English, Spanish, and Japanese — no human editors in the loop.
 
 ## Leadership
 


### PR DESCRIPTION
TrendPulse is a daily, fully autonomous digest of trending tech and business videos worldwide, delivered in English, Spanish, and Japanese. No human editors are involved between trend collection and delivery — the pipeline (YouTube Data API v3 → Claude → Mailgun) is open source: https://github.com/usagineko7865-debug/trendpulse

Live demo / signup: https://usagineko7865-debug.github.io/trendpulse/

Added one line, alphabetically/contextually placed at the end of the Technology in General section per the contribution guidelines.