### PR TITLE
Add Storefront Brief to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [The Marketing Newsletter](http://themarketingnewsletter.org) - Ideas to help marketers and creators grow faster and work smarter
 - [Geekout Newsletter](https://geekout.mattnavarra.com/) - latest social media platform news, tips, tools, and new features
 
-- [Storefront Brief](https://fortune-insight.onrender.com/shop/). Weekend teardowns of 12-20 USD storefront tools, with a free sample on Telegram.
+- [Storefront Brief](https://fortune-insight.onrender.com/shop/). Weekend teardowns of \-\ storefront tools, with a free sample on Telegram.
 
 ## Business/Finance
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Swift Developments](https://andybargh.com/swiftdevelopments/). Weekly curated newsletter containing a hand picked selection of the latest links, videos, tools and tutorials for people interested in designing and developing their own iOS, macOS, watchOS and tvOS apps using Swift.
 - [iOS Dev Tools Newsletter](https://iosdev.tools/). The best tools for iOS developers, updated weekly.
 - [Indie Watch](https://indie.watch/). Weekly interviews with successful iOS & macOS developers about strategies and tips you can use to create profitable indie apps.
+- [Storefront Brief](https://fortune-insight.onrender.com/shop/). Weekly App Store policy and fee notes for indie iOS teams shipping internationally. Free English sample. [Archive](https://fortune-insight.onrender.com/shop/brief/issue-001-en.html).
 
 ### Go
 
@@ -486,8 +487,6 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [The Content Odyssey](https://newsletter.mktodyssey.com/). Biweekly tried-and-tested content growth experiments.
 - [The Marketing Newsletter](http://themarketingnewsletter.org) - Ideas to help marketers and creators grow faster and work smarter
 - [Geekout Newsletter](https://geekout.mattnavarra.com/) - latest social media platform news, tips, tools, and new features
-
-- [Storefront Brief](https://fortune-insight.onrender.com/shop/). Weekend teardowns of \-\ storefront tools, with a free sample on Telegram.
 
 ## Business/Finance
 

--- a/README.md
+++ b/README.md
@@ -487,6 +487,8 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [The Marketing Newsletter](http://themarketingnewsletter.org) - Ideas to help marketers and creators grow faster and work smarter
 - [Geekout Newsletter](https://geekout.mattnavarra.com/) - latest social media platform news, tips, tools, and new features
 
+- [Storefront Brief](https://fortune-insight.onrender.com/shop/). Weekend teardowns of 12-20 USD storefront tools, with a free sample on Telegram.
+
 ## Business/Finance
 
 - [The Pricing Newsletter](https://taprun.com/newsletter/). Q&As, lessons, and news articles to help startups and business owners understand how to implement pricing strategy.


### PR DESCRIPTION
## Why

[Storefront Brief](https://fortune-insight.onrender.com/shop/) is a weekly English newsletter of App Store policy and fee notes for indie iOS teams shipping internationally (EU / US / Asia).

- Sample: https://fortune-insight.onrender.com/shop/brief/issue-001-en.html
- RSS: https://fortune-insight.onrender.com/shop/brief/feed.xml
- Publisher: Fortune Insight, LLC
- Paid brief: $12/month

Placed in the Swift section (not Marketing). Format matches CONTRIBUTING ([Name](link). Description.).