### PR TITLE
Add Ultrathink — daily Korean AI newsletter for non-developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Data Elixir](https://dataelixir.com/). A weekly newsletter of the best data science news and resources from around the web. [Archive](https://dataelixir.com/newsletters/).
 - [Artificial Intelligence Weekly](http://aiweekly.co/). A weekly collection of the best news and resources on Artificial Intelligence and Machine Learning.
 - [Machine Learnings](http://subscribe.machinelearnings.co/). A weekly roundup of ML & AI news.
+- [Ultrathink](https://ai-morning-report-landing.vercel.app). A daily Korean AI newsletter for non-developers — the 7 stories that actually change your tools, costs, and workflow, in a 5-minute read.
 - [Inside AI](https://inside.com/ai). Weekly newsletter bringing you the latest in Artificial Intelligence, Robotics, and Neurotechnology.
 - [Import AI](https://twitter.us13.list-manage.com/subscribe?u=67bd06787e84d73db24fb0aa5&id=6c9d98ff2c). The latest breakthroughs, applications and foul-ups in artificial intelligence. [Archive](https://us13.campaign-archive.com/home/?u=67bd06787e84d73db24fb0aa5&id=6c9d98ff2c)
 - [The ML Engineer Newsletter](https://ethical.institute/mle.html). Receive updates on open source frameworks, tutorials and articles curated by machine learning professionals. Obtain insights on best practices, tools and techniques in machine learning explainability, reproducibility, model evaluation, feature analysis and beyond.


### PR DESCRIPTION
Adding [Ultrathink](https://ai-morning-report-landing.vercel.app) to the AI/ML section.

- Daily (weekday mornings), Korean language
- Curates the 7 AI stories that actually change a non-developer's tools, costs, and workflow
- 5-minute read format
- Free first month

Fits the existing list's criteria: active, regularly published, focused topic.