### PR TITLE
Add The Bitcoin Act to Blockchain / Cryptocurrencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Inside Cryptocurrency](https://inside.com/cryptocurrency). Tracking trends, news, and analysis around Bitcoin and cryptocurrencies.
 - [Crypto Weekly](https://cryptoweekly.co/). The best cryptocurrency news and insights delivered to your inbox every week.
 - [Build Blockchain](https://www.buildblockchain.tech/newsletter). Blockchain tech without the bull— a weekly dose of blockchain reality with a heavy bias toward the technical.
+- [The Bitcoin Act](https://thebitcoinact.xyz). Twice-weekly newsletter covering Bitcoin law, regulation and policy in the US and internationally.
 
 ## Technology in General
 


### PR DESCRIPTION
Adding https://thebitcoinact.xyz, a twice-weekly newsletter on Bitcoin law and regulation. The Blockchain / Cryptocurrencies section currently has three entries and none cover the legal or regulatory side. It tracks US legislation, agency action and international regulatory developments, and maintains a map of Bitcoin's legal status in 140 countries.