### PR TITLE
Add The Autonomous Edge newsletter

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ Thanks to all [contributors](https://github.com/zudochkin/awesome-newsletters/gr
 - [Augmented Coding Weekly](https://augmentedcoding.dev/). A weekly newsletter that takes a hype-free look at the latest news about AI-augmented software development and vibe coding, with a focus on how it is changing the software industry
 - [Adapt or Die](https://adaptordie.io). Independent analysis of AI's impact on commerce — covering agentic commerce, AI infrastructure spending, and digital transformation with long-form, zero-hype takes.
 - [AI Dev Jobs Weekly](https://aidevboard.com). A weekly digest of the latest AI and machine learning developer jobs from 280+ companies including Anthropic, OpenAI, and DeepMind.
+- [The Autonomous Edge](https://buttondown.com/TheAutonomousEdge?utm_source=github.com/zudochkin/awesome-newsletters). Weekly briefing on AI agents and enterprise automation — real deployments, funding, security disclosures, and the adoption data behind the headlines.
 
 ## Blockchain / Cryptocurrencies
 


### PR DESCRIPTION
Adding The Autonomous Edge (https://buttondown.com/TheAutonomousEdge) to the "Artificial Intelligence / Machine Learning / Big Data" section — a weekly briefing on AI agents and enterprise automation, covering real deployments, funding, security disclosures, and the adoption data behind the headlines. Matches the existing entry format used in that section. Thanks for maintaining this list!